### PR TITLE
fix compilation error with Qt 5.5

### DIFF
--- a/src/libtomahawk/network/acl/AclRegistry.cpp
+++ b/src/libtomahawk/network/acl/AclRegistry.cpp
@@ -21,6 +21,7 @@
 
 #include <QThread>
 #include <QVariant>
+#include <QDataStream>
 
 #include "utils/Logger.h"
 

--- a/src/libtomahawk/utils/TomahawkCache.h
+++ b/src/libtomahawk/utils/TomahawkCache.h
@@ -27,6 +27,7 @@
 #include <QObject>
 #include <QTimer>
 #include <QDir>
+#include <QDataStream>
 
 namespace TomahawkUtils
 {


### PR DESCRIPTION
HI.

From Qt 5.5 we need to include QDataStream explicitly, otherwise cause compilation error like following.

/home/kenya888/devel/github/tomahawk/src/libtomahawk/network/acl/AclRegistry.cpp: In function 'QDataStream& operator<<(QDataStream&, const ACLRegistry::User&)':
/home/kenya888/devel/github/tomahawk/src/libtomahawk/network/acl/AclRegistry.cpp:30:9: error: ambiguous overload for 'operator<<' (operand types are 'QDataStream' and 'int')
out << ACLUSERVERSION;
^
/home/kenya888/devel/github/tomahawk/src/libtomahawk/network/acl/AclRegistry.cpp:30:9: note: candidates are:
In file included from /opt/qt/5.5/gcc/include/QtCore/qhash.h:38:0,
from /opt/qt/5.5/gcc/include/QtCore/qshareddata.h:39,
from /opt/qt/5.5/gcc/include/QtCore/qsharedpointer.h:39,
from /opt/qt/5.5/gcc/include/QtCore/QSharedPointer:1,
from /home/kenya888/devel/github/tomahawk/src/libtomahawk/Typedefs.h:24,
from /home/kenya888/devel/github/tomahawk/src/libtomahawk/network/acl/AclRequest.h:22,
from /home/kenya888/devel/github/tomahawk/src/libtomahawk/network/acl/AclRegistry.h:23,
from /home/kenya888/devel/github/tomahawk/src/libtomahawk/network/acl/AclRegistry.cpp:20:
/opt/qt/5.5/gcc/include/QtCore/qchar.h:584:28: note: QDataStream& operator<<(QDataStream&, QChar)
Q_CORE_EXPORT QDataStream &operator<<(QDataStream &, QChar);